### PR TITLE
Add Codex environment guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Codex Contribution Guide
+
+This file provides guidance for running Codex in the `chat-frontier-flora` repository.
+
+## Project Overview
+- Cross-platform chat application using Expo, React Native Web, and Supabase.
+- Node.js >= 18.18 required. Repo uses monorepo workspaces (`apps/` and `packages/`).
+- Tests use the Stagehand framework with Playwright.
+- Python tools exist for OpenAI integration (see `requirements.txt`).
+
+## Recommended Startup
+Run `./scripts/setup-codex.sh` from the repository root. It:
+1. Installs Node 18 via `nvm` if necessary.
+2. Runs `npm install` to install workspace dependencies.
+3. Installs Playwright browsers.
+4. Installs Python requirements if `requirements.txt` exists.
+5. Runs `npm run status:check` and `./scripts/verify-test-status.sh` to verify environment configuration.
+
+## Testing
+- Execute `npm run test:safe` to run Stagehand E2E tests after verification.
+- `scripts/verify-test-status.sh` checks that environment variables like `OPENAI_API_KEY` are set and ensures only the Stagehand test files run.
+- Quarantined tests live in `e2e/quarantined-playwright-tests`; do not run them.
+
+## Environment Files
+- A `.env` file exists in the project root. Verify with `ls -la | grep env`.
+- During builds it is copied to `apps/web/.env` automatically.
+- See `docs/PROJECT_CONTEXT.md` and `docs/ENVIRONMENT_FILE_CHECKLIST.md` for details.
+
+## Development Workflow
+- Always run Expo from `apps/web` (`cd apps/web && npm run web`).
+- Follow the step-by-step workflow in `docs/DEVELOPMENT_WORKFLOW_CHECKLIST.md` before creating a pull request.
+- Preview deploys are required before merging to `main`.
+
+## Codex Environment Notes
+- The container is ephemeral and resets for each session.
+- You have root access but network connectivity may be limited; use the startup script to install dependencies early.
+- Keep the git worktree clean and commit frequently.
+- Consult `docs/CURRENT_TEST_INVENTORY.md` to understand current test coverage.
+

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Codex Startup Script for chat-frontier-flora
+# Installs dependencies and verifies environment
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "==> Initializing Codex environment..."
+
+# Ensure Node 18 is available
+REQUIRED_NODE="18"
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node not found. Installing Node $REQUIRED_NODE via nvm" >&2
+fi
+
+if command -v node >/dev/null 2>&1; then
+  NODE_MAJOR=$(node -v | sed 's/v\([0-9]*\).*/\1/')
+else
+  NODE_MAJOR="0"
+fi
+
+if [ "$NODE_MAJOR" != "$REQUIRED_NODE" ]; then
+  if ! command -v nvm >/dev/null 2>&1; then
+    echo "Installing nvm..."
+    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  else
+    export NVM_DIR="$HOME/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  fi
+  echo "Installing Node 18..."
+  nvm install 18
+  nvm use 18
+fi
+
+node -v
+npm -v
+
+# Install npm dependencies
+npm install
+
+# Install Playwright browsers
+npx playwright install --with-deps
+
+# Python dependencies (if any)
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
+
+# Verify environment
+npm run status:check || true
+./scripts/verify-test-status.sh || true
+
+echo "==> Codex environment setup complete"


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with instructions for running Codex
- provide `scripts/setup-codex.sh` to install required tooling

## Testing
- `./scripts/verify-test-status.sh` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68483d896818832f8d1d7c33b41637be