### PR TITLE
Fix build scripts for Metro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,6 @@ npm run dev:mobile -- --android # Android emulator
 ```bash
 # Build web application (Expo web export)
 cd apps/web && npm run build
-# OR from root
-npm run build:web
 
 # Build mobile (requires EAS setup)
 npm run build:mobile

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "web": "cp ../../.env .env 2>/dev/null || true && npx expo start --web --port 19006",
     "test": "jest",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
-    "build": "expo export:web"
+    "build": "expo export"
   },
   "dependencies": {
     "@chat-frontier-flora/shared": "*",

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build:web"
+  command = "cd apps/web && npx expo export"
   publish = "apps/web/web-build"
   functions = "netlify/functions"
 


### PR DESCRIPTION
## Summary
- update netlify to use expo export
- document building the web export from apps/web

## Testing
- `npm run test:safe` *(fails: Could not read package.json)*
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6853ef0f4494832f86b0729ec3625225