### PR TITLE
Restore root package.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,6 @@ npm run dev:mobile -- --android # Android emulator
 ```bash
 # Build web application (Expo web export)
 cd apps/web && npm run build
-# OR from root
-npm run build:web
 
 # Build mobile (requires EAS setup)
 npm run build:mobile

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "web": "cp ../../.env .env 2>/dev/null || true && npx expo start --web --port 19006",
     "test": "jest",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
-    "build": "expo export:web"
+    "build": "expo export --output-dir web-build"
   },
   "dependencies": {
     "@chat-frontier-flora/shared": "*",

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm run build:web"
+  command = "cd apps/web && npm run build"
   publish = "apps/web/web-build"
   functions = "netlify/functions"
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "chat-frontier-flora",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "mkdir -p apps/web/web-build && echo 'Static build ready - HTML file already exists'",
+    "build:expo": "cd apps/web && npx expo export",
+    "dev:web": "cd apps/web && npm run web",
+    "dev:mobile": "npm run start -w @chat-frontier-flora/mobile",
+    "build:web": "cd apps/web && npx expo export --output-dir web-build",
+    "build:mobile": "cd apps/mobile && eas build",
+    "test": "npm run test --workspaces --if-present",
+    "test:e2e": "playwright test e2e/stagehand-auth-test.spec.ts e2e/stagehand-production-auth.spec.ts",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
+    "test:visual": "playwright test --update-snapshots",
+    "test:all": "npm test && npm run test:e2e",
+    "lint": "npm run lint --workspaces --if-present",
+    "postinstall": "npm run build -w @chat-frontier-flora/shared",
+    "verify:test-env": "./scripts/verify-test-status.sh",
+    "test:safe": "./scripts/verify-test-status.sh && npm run test:e2e",
+    "test:localhost": "unset DEPLOY_PREVIEW_URL && npm run test:e2e",
+    "test:production": "unset DEPLOY_PREVIEW_URL && playwright test e2e/stagehand-production-auth.spec.ts",
+    "dev:safe": "./scripts/verify-test-status.sh && cd apps/web && npm run web",
+    "status:check": "echo 'Directory:' && pwd && echo 'Expo processes:' && ps aux | grep expo | grep -v grep || echo 'None' && echo 'Environment:' && echo \"DEPLOY_PREVIEW_URL: $DEPLOY_PREVIEW_URL\" && echo \"OPENAI_API_KEY: $([ -n \"$OPENAI_API_KEY\" ] && echo 'Set' || echo 'Not set')\"",
+    "test:e2e:login": "playwright test e2e/stagehand-login-test.spec.ts"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
+    "@netlify/edge-functions": "^2.14.5",
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^20.0.0",
+    "buffer": "^6.0.3",
+    "crypto-browserify": "^3.12.1",
+    "eslint": "^8.0.0",
+    "nativewind": "^4.1.23",
+    "prettier": "^3.0.0",
+    "stream-browserify": "^3.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand": "^2.3.0",
+    "@react-navigation/native": "^7.1.10",
+    "@react-navigation/stack": "^7.1.1",
+    "puppeteer": "^24.10.1",
+    "react-native-markdown-display": "^7.0.2",
+    "react-native-reanimated": "^3.18.0",
+    "react-native-safe-area-context": "^5.4.1",
+    "react-native-screens": "^4.11.1",
+    "react-native-web": "^0.19.13",
+    "zod": "^3.25.56"
+  },
+  "overrides": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-test-renderer": "18.2.0",
+    "@types/react": "~18.2.45"
+  },
+  "resolutions": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-test-renderer": "18.2.0",
+    "@types/react": "~18.2.45"
+  }
+}


### PR DESCRIPTION
## Summary
- restore missing root `package.json`
- add Metro-compatible build scripts

## Testing
- `./scripts/setup-codex.sh`
- `npm run web` *(fails: SHA-1 file error in Metro)*
- `npm run build:web` *(fails: SHA-1 file error)*


------
https://chatgpt.com/codex/tasks/task_e_6853ef0f4494832f86b0729ec3625225